### PR TITLE
Add licensing authentication flow and gate exam access

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A modern, interactive web application for creating and practicing mock exams. Bu
 - **💾 Progress Saving**: Auto-save exam progress to localStorage
 - **📊 Category Analytics**: Performance breakdown by question categories
 - **🎯 Advanced Settings**: Customizable timer warnings, navigation options, and more
+- **🔐 License Gating**: Server-issued JWT sessions ensure only licensed users can launch exams
 
 ## 🛠️ Installation
 
@@ -48,12 +49,17 @@ A modern, interactive web application for creating and practicing mock exams. Bu
    npm install
    ```
 
-3. **Start development server**
+3. **Start the licensing API** (in a separate terminal)
+   ```bash
+   npm run server
+   ```
+
+4. **Start development server**
    ```bash
    npm run dev
    ```
 
-4. **Open in browser**
+5. **Open in browser**
    Navigate to `http://localhost:3000`
 
 ### Production Build
@@ -143,6 +149,16 @@ IQN EXAM/
 ├── public/              # Static assets
 └── package.json         # Dependencies
 ```
+
+## 🔐 Authentication & Licensing
+
+- The app requires a server-validated license before exams can start. The bundled Node service (`npm run server`) issues signed JWT cookies and checks expiration/revocation on every exam launch.
+- The frontend only persists non-sensitive flags (e.g., whether the license prompt was dismissed); license keys and tokens stay on the server.
+- Sample license keys for local testing:
+  - ✅ `IQN-VALID-0001` – active through 1 Jan 2026
+  - ⛔ `IQN-EXPIRED-0000` – shows the expired license flow
+  - 🚫 `IQN-REVOKED-0000` – demonstrates revoked-license messaging
+- Sign out any time from the header to clear the session cookie.
 
 ## 🎨 Customization
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "server": "node server/index.js"
   },
   "keywords": [
     "exam",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,303 @@
+import { createServer } from 'node:http';
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+const PORT = Number(process.env.PORT || 4000);
+const JWT_SECRET = process.env.JWT_SECRET || 'development-secret-change-me';
+const COOKIE_NAME = 'iqn_session';
+const TOKEN_TTL_HOURS = 4;
+const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN || 'http://localhost:3000';
+
+const LICENSES = [
+  {
+    key: 'IQN-VALID-0001',
+    owner: 'Demo Candidate',
+    plan: 'Pro',
+    expiresAt: new Date('2026-01-01T00:00:00Z').toISOString(),
+    revoked: false
+  },
+  {
+    key: 'IQN-EXPIRED-0000',
+    owner: 'Expired Candidate',
+    plan: 'Standard',
+    expiresAt: new Date('2024-01-01T00:00:00Z').toISOString(),
+    revoked: false
+  },
+  {
+    key: 'IQN-REVOKED-0000',
+    owner: 'Revoked Candidate',
+    plan: 'Starter',
+    expiresAt: new Date('2026-01-01T00:00:00Z').toISOString(),
+    revoked: true
+  }
+];
+
+const toBase64Url = (buffer) => Buffer.from(buffer).toString('base64url');
+
+const signJwt = (payload, secret, hours = TOKEN_TTL_HOURS) => {
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const exp = Math.floor(Date.now() / 1000) + hours * 60 * 60;
+  const fullPayload = { ...payload, exp };
+
+  const headerEncoded = toBase64Url(JSON.stringify(header));
+  const payloadEncoded = toBase64Url(JSON.stringify(fullPayload));
+  const signature = createHmac('sha256', secret)
+    .update(`${headerEncoded}.${payloadEncoded}`)
+    .digest('base64url');
+
+  return `${headerEncoded}.${payloadEncoded}.${signature}`;
+};
+
+const verifyJwt = (token, secret) => {
+  if (!token) return null;
+  const [headerEncoded, payloadEncoded, signature] = token.split('.');
+  if (!headerEncoded || !payloadEncoded || !signature) return null;
+
+  const expectedSignature = createHmac('sha256', secret)
+    .update(`${headerEncoded}.${payloadEncoded}`)
+    .digest();
+  const providedSignature = Buffer.from(signature, 'base64url');
+
+  if (expectedSignature.length !== providedSignature.length ||
+      !timingSafeEqual(expectedSignature, providedSignature)) {
+    return null;
+  }
+
+  try {
+    const payload = JSON.parse(Buffer.from(payloadEncoded, 'base64url').toString('utf8'));
+    if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) {
+      return null;
+    }
+    return payload;
+  } catch (error) {
+    return null;
+  }
+};
+
+const findLicense = (licenseKey = '') => {
+  const normalised = licenseKey.trim().toUpperCase();
+  return LICENSES.find((license) => license.key === normalised) || null;
+};
+
+const licenseToClient = (license) => ({
+  owner: license.owner,
+  plan: license.plan,
+  expiresAt: license.expiresAt,
+  licenseKeyLast4: license.key.slice(-4)
+});
+
+const validateLicense = (license) => {
+  if (!license) {
+    return { valid: false, reason: 'invalid' };
+  }
+
+  if (license.revoked) {
+    return { valid: false, reason: 'revoked', license };
+  }
+
+  const expiresAt = new Date(license.expiresAt);
+  if (Number.isNaN(expiresAt.getTime())) {
+    return { valid: false, reason: 'invalid', license };
+  }
+
+  if (new Date() > expiresAt) {
+    return { valid: false, reason: 'expired', license };
+  }
+
+  return { valid: true, license };
+};
+
+const parseCookies = (cookieHeader = '') => {
+  return cookieHeader.split(';').reduce((acc, pair) => {
+    const [key, ...rest] = pair.trim().split('=');
+    if (!key) return acc;
+    acc[key] = decodeURIComponent(rest.join('='));
+    return acc;
+  }, {});
+};
+
+const readJsonBody = async (req) => {
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(chunk);
+  }
+
+  if (chunks.length === 0) return {};
+
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+  } catch (error) {
+    return {};
+  }
+};
+
+const setCorsHeaders = (res) => {
+  res.setHeader('Access-Control-Allow-Origin', ALLOWED_ORIGIN);
+  res.setHeader('Access-Control-Allow-Credentials', 'true');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  res.setHeader('Vary', 'Origin');
+};
+
+const sendJson = (res, statusCode, payload) => {
+  res.statusCode = statusCode;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.end(JSON.stringify(payload));
+};
+
+const setSessionCookie = (res, token) => {
+  const maxAge = TOKEN_TTL_HOURS * 60 * 60;
+  const parts = [
+    `${COOKIE_NAME}=${token}`,
+    'Path=/',
+    `Max-Age=${maxAge}`,
+    'HttpOnly',
+    'SameSite=Lax'
+  ];
+  if (process.env.NODE_ENV === 'production') {
+    parts.push('Secure');
+  }
+  res.setHeader('Set-Cookie', parts.join('; '));
+};
+
+const clearSessionCookie = (res) => {
+  const parts = [
+    `${COOKIE_NAME}=`,
+    'Path=/',
+    'Max-Age=0',
+    'HttpOnly',
+    'SameSite=Lax'
+  ];
+  if (process.env.NODE_ENV === 'production') {
+    parts.push('Secure');
+  }
+  res.setHeader('Set-Cookie', parts.join('; '));
+};
+
+const handleSession = (req, res) => {
+  const cookies = parseCookies(req.headers.cookie);
+  const token = cookies[COOKIE_NAME];
+  const decoded = verifyJwt(token, JWT_SECRET);
+
+  if (!decoded) {
+    clearSessionCookie(res);
+    return sendJson(res, 401, { error: 'not_authenticated' });
+  }
+
+  const license = findLicense(decoded.licenseKey);
+  const validation = validateLicense(license);
+
+  if (!validation.valid) {
+    clearSessionCookie(res);
+    const { reason } = validation;
+    if (reason === 'expired') {
+      return sendJson(res, 403, {
+        error: 'license_expired',
+        message: 'Your license has expired. Please renew to continue.',
+        license: license ? licenseToClient(license) : null
+      });
+    }
+
+    if (reason === 'revoked') {
+      return sendJson(res, 403, {
+        error: 'license_revoked',
+        message: 'This license has been revoked. Contact support for assistance.',
+        license: license ? licenseToClient(license) : null
+      });
+    }
+
+    return sendJson(res, 401, { error: 'not_authenticated' });
+  }
+
+  return sendJson(res, 200, {
+    message: 'Session validated',
+    license: licenseToClient(validation.license)
+  });
+};
+
+const handleLogin = async (req, res) => {
+  const body = await readJsonBody(req);
+  const license = findLicense(body.licenseKey || '');
+  const validation = validateLicense(license);
+
+  if (!validation.valid) {
+    const { reason } = validation;
+    if (reason === 'expired') {
+      clearSessionCookie(res);
+      return sendJson(res, 403, {
+        error: 'license_expired',
+        message: 'Your license expired. Enter a new key to continue.',
+        license: license ? licenseToClient(license) : null
+      });
+    }
+
+    if (reason === 'revoked') {
+      clearSessionCookie(res);
+      return sendJson(res, 403, {
+        error: 'license_revoked',
+        message: 'This license has been revoked. Please contact support.',
+        license: license ? licenseToClient(license) : null
+      });
+    }
+
+    return sendJson(res, 401, {
+      error: 'invalid_license',
+      message: 'License key not recognised.'
+    });
+  }
+
+  const token = signJwt({ licenseKey: validation.license.key }, JWT_SECRET);
+  setSessionCookie(res, token);
+
+  return sendJson(res, 200, {
+    message: 'License verified successfully',
+    license: licenseToClient(validation.license)
+  });
+};
+
+const handleLogout = (res) => {
+  clearSessionCookie(res);
+  return sendJson(res, 200, { message: 'Signed out' });
+};
+
+const server = createServer(async (req, res) => {
+  setCorsHeaders(res);
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  const url = new URL(req.url || '/', `http://${req.headers.host}`);
+  const { pathname } = url;
+
+  if (pathname === '/api/auth/session' && req.method === 'GET') {
+    handleSession(req, res);
+    return;
+  }
+
+  if (pathname === '/api/auth/login' && req.method === 'POST') {
+    await handleLogin(req, res);
+    return;
+  }
+
+  if (pathname === '/api/auth/logout' && req.method === 'POST') {
+    handleLogout(res);
+    return;
+  }
+
+  if (pathname === '/health' && req.method === 'GET') {
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    res.end(JSON.stringify({ status: 'ok' }));
+    return;
+  }
+
+  res.statusCode = 404;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.end(JSON.stringify({ error: 'not_found' }));
+});
+
+server.listen(PORT, () => {
+  console.log(`Auth server listening on port ${PORT}`);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Play, ListChecks, Moon, Sun, Github } from 'lucide-react';
+import { Play, ListChecks, Moon, Sun, Github, LogOut, ShieldCheck, KeyRound, AlertCircle, Loader2 } from 'lucide-react';
 import { ExamView, ReviewView } from './components';
-import { Button, Badge } from './components/ui';
+import { Button, Badge, Card, CardHeader, CardTitle, CardDescription, CardContent } from './components/ui';
 import { useExamStore } from './store/useExamStore';
 import { useTimer } from './hooks/useTimer';
 import { calcSummary, shuffleInPlace } from './utils/helpers';
@@ -36,7 +36,18 @@ function App() {
     qaCursor,
     setQACoverage,
     selectedSet,
-    setSelectedSet
+    setSelectedSet,
+    authStatus,
+    license,
+    authError,
+    authLoading,
+    licenseValidationPending,
+    hasDismissedLicensePrompt,
+    authenticateWithLicense,
+    checkExistingSession,
+    confirmLicense,
+    signOut,
+    setAuthError
   } = useExamStore();
 
   const timer = useTimer({
@@ -52,6 +63,42 @@ function App() {
     warningTime: settings.timeWarningMinutes * 60
   });
 
+  const [licenseInput, setLicenseInput] = useState('');
+
+  const licenseExpiryText = React.useMemo(() => {
+    if (!license?.expiresAt) return null;
+    const expiry = new Date(license.expiresAt);
+    if (Number.isNaN(expiry.getTime())) return null;
+    return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(expiry);
+  }, [license]);
+
+  const isAuthBusy = authLoading || authStatus === 'loading';
+  const shouldShowLicensePrompt =
+    authStatus !== 'authenticated' &&
+    (!hasDismissedLicensePrompt || (authStatus !== 'loading' && authStatus !== 'unknown'));
+
+  useEffect(() => {
+    if (authStatus === 'authenticated') {
+      setLicenseInput('');
+    }
+  }, [authStatus]);
+
+  const handleLicenseSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await authenticateWithLicense(licenseInput);
+  };
+
+  const handleLicenseInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (authError) {
+      setAuthError(null);
+    }
+    setLicenseInput(event.target.value);
+  };
+
+  const handleSignOut = () => {
+    void signOut();
+  };
+
   // Dark mode effect
   useEffect(() => {
     if (isDarkMode) {
@@ -63,16 +110,14 @@ function App() {
     }
   }, [isDarkMode]);
 
-  // Always start a fresh exam from QA.json on first mount (ensures new set on refresh)
+  // Check for any persisted session from the licensing server when the app mounts
   useEffect(() => {
-    startNewExamFromQA();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    void checkExistingSession();
+  }, [checkExistingSession]);
 
   // Remove fixed default duration; duration will be set to number of questions when building the exam
 
-  // Start a new exam from QA.json using questions for the selected set
-  const startNewExamFromQA = () => {
+  const buildExamFromQA = React.useCallback(() => {
     const all = loadAllQAQuestions();
     let questions = getExamSetQuestions(all, selectedSet, 100, 15);
     const { order, cursor } = pickWithCoverage(questions, qaOrder || undefined, qaCursor, questions.length);
@@ -82,14 +127,38 @@ function App() {
     }
     const built = buildExamFromQuestions(questions, `IQN Practice Exam • Set ${selectedSet}`);
     setExam(built);
-    // Fixed timing per set: 100 minutes
     if (settings.minutes !== 100) {
       updateSettings({ minutes: 100 });
     }
     setQACoverage(order, cursor);
     startSession(`exam_${Date.now()}`);
     setStage('exam');
-  };
+  }, [
+    qaOrder,
+    qaCursor,
+    selectedSet,
+    settings.shuffleChoices,
+    settings.minutes,
+    setExam,
+    updateSettings,
+    setQACoverage,
+    startSession,
+    setStage
+  ]);
+
+  const handleStartNewExam = React.useCallback(async () => {
+    const isValid = await confirmLicense();
+    if (!isValid) {
+      return;
+    }
+    buildExamFromQA();
+  }, [confirmLicense, buildExamFromQA]);
+
+  useEffect(() => {
+    if (authStatus === 'authenticated' && !exam && !session && hasDismissedLicensePrompt) {
+      void handleStartNewExam();
+    }
+  }, [authStatus, exam, session, hasDismissedLicensePrompt, handleStartNewExam]);
 
   // Ensure timer reflects current settings.minutes (number of questions) when exam starts
   useEffect(() => {
@@ -148,11 +217,113 @@ function App() {
     <div className="min-h-screen bg-gradient-to-br from-indigo-50 via-purple-50 to-pink-50 dark:from-gray-950 dark:via-black dark:to-gray-950 transition-colors duration-300">
       {/* Background Pattern */}
       <div className="fixed inset-0 opacity-20 dark:opacity-10">
-        <div className="absolute inset-0" style={{
+      <div className="absolute inset-0" style={{
           backgroundImage: `radial-gradient(circle at 2px 2px, currentColor 1px, transparent 1px)`,
           backgroundSize: '40px 40px'
         }} />
       </div>
+
+      <AnimatePresence>
+        {shouldShowLicensePrompt && (
+          <motion.div
+            key="license-gate"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/70 backdrop-blur-md px-4"
+          >
+            <motion.div
+              initial={{ opacity: 0, y: 24 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -12 }}
+              transition={{ duration: 0.2 }}
+              className="w-full max-w-lg"
+            >
+              <Card className="shadow-2xl">
+                <CardHeader className="space-y-4">
+                  <div className="flex items-center gap-3">
+                    <div className="rounded-2xl bg-indigo-100 dark:bg-indigo-900/30 p-3 text-indigo-600 dark:text-indigo-300">
+                      <ShieldCheck size={28} />
+                    </div>
+                    <div>
+                      <CardTitle>Verify your license</CardTitle>
+                      <CardDescription>
+                        Enter a valid IQN practice license to unlock the exam workspace.
+                      </CardDescription>
+                    </div>
+                  </div>
+
+                  {authStatus === 'loading' && !authError && (
+                    <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Validating your existing session...
+                    </div>
+                  )}
+
+                  {authStatus === 'expired' && license && (
+                    <div className="flex items-start gap-2 rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-600 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-300">
+                      <AlertCircle className="mt-0.5 h-4 w-4" />
+                      <span>
+                        License ending in {license.licenseKeyLast4}
+                        {licenseExpiryText ? ` expired on ${licenseExpiryText}` : ' has expired'}. Enter a renewed key to continue.
+                      </span>
+                    </div>
+                  )}
+
+                  {authError && (
+                    <div className="flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-600 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300">
+                      <AlertCircle className="mt-0.5 h-4 w-4" />
+                      <span>{authError}</span>
+                    </div>
+                  )}
+                </CardHeader>
+
+                <CardContent className="space-y-6">
+                  <form onSubmit={handleLicenseSubmit} className="space-y-4">
+                    <label className="flex flex-col gap-2 text-sm text-gray-700 dark:text-gray-200">
+                      License key
+                      <div className="flex items-center gap-2 rounded-xl border border-gray-300 bg-white px-3 py-2 focus-within:ring-2 focus-within:ring-indigo-400 dark:border-gray-700 dark:bg-gray-900">
+                        <KeyRound className="h-4 w-4 text-indigo-500" />
+                        <input
+                          type="text"
+                          value={licenseInput}
+                          onChange={handleLicenseInputChange}
+                          placeholder="e.g. IQN-VALID-0001"
+                          className="flex-1 border-none bg-transparent text-sm text-gray-900 outline-none placeholder:text-gray-400 dark:text-gray-100 dark:placeholder:text-gray-600"
+                          disabled={isAuthBusy}
+                          autoFocus
+                        />
+                      </div>
+                    </label>
+
+                    <Button type="submit" variant="primary" size="lg" className="w-full" disabled={isAuthBusy}>
+                      {isAuthBusy ? (
+                        <>
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          Checking key...
+                        </>
+                      ) : (
+                        <>
+                          <ShieldCheck className="mr-2 h-4 w-4" />
+                          Verify license
+                        </>
+                      )}
+                    </Button>
+                  </form>
+
+                  <div className="rounded-xl bg-indigo-50 px-4 py-3 text-xs text-indigo-700 dark:bg-indigo-900/20 dark:text-indigo-200">
+                    <p className="font-medium text-sm">Need a demo key?</p>
+                    <p className="mt-1">Use <code className="font-mono text-xs">IQN-VALID-0001</code> when exploring locally.</p>
+                    <p className="mt-2 text-[11px] text-indigo-500 dark:text-indigo-300">
+                      Licensing is validated on the server—no secrets are stored in your browser.
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       <div className="relative max-w-7xl mx-auto p-4 sm:p-6 lg:p-8">
         {/* Header */}
@@ -171,7 +342,7 @@ function App() {
               </p>
             </div>
             
-            <div className="flex items-center gap-3">
+            <div className="flex flex-col items-center gap-3 sm:flex-row sm:items-end">
               {/* Stage Navigation (Builder removed) */}
               <div className="flex items-center gap-2 p-1 bg-white/50 dark:bg-gray-900/50 backdrop-blur-sm rounded-xl">
                 <select
@@ -189,7 +360,7 @@ function App() {
                   variant={stage === 'exam' ? 'primary' : 'ghost'}
                   size="sm"
                   onClick={() => setStage('exam')}
-                  disabled={!canNavigateTo('exam')}
+                  disabled={authStatus !== 'authenticated' || !canNavigateTo('exam')}
                 >
                   <Play size={18} />
                   <span className="hidden sm:inline">Exam</span>
@@ -198,7 +369,7 @@ function App() {
                   variant={stage === 'review' ? 'primary' : 'ghost'}
                   size="sm"
                   onClick={() => setStage('review')}
-                  disabled={!canNavigateTo('review')}
+                  disabled={authStatus !== 'authenticated' || !canNavigateTo('review')}
                 >
                   <ListChecks size={18} />
                   <span className="hidden sm:inline">Review</span>
@@ -206,41 +377,82 @@ function App() {
                 <Button
                   variant="secondary"
                   size="sm"
-                  onClick={() => startNewExamFromQA()}
+                  onClick={() => { void handleStartNewExam(); }}
+                  disabled={authStatus !== 'authenticated' || licenseValidationPending}
                 >
+                  {licenseValidationPending ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : null}
                   New Exam
                 </Button>
+                {license && authStatus === 'authenticated' && (
+                  <Badge variant="success" size="sm" className="sm:hidden flex items-center gap-1">
+                    <ShieldCheck className="h-3 w-3" />
+                    Key • {license.licenseKeyLast4}
+                  </Badge>
+                )}
               </div>
 
-              {/* Dark Mode Toggle */}
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => setIsDarkMode(!isDarkMode)}
-                className="p-2"
-              >
-                <AnimatePresence mode="wait">
-                  {isDarkMode ? (
-                    <motion.div
-                      key="moon"
-                      initial={{ rotate: -90, opacity: 0 }}
-                      animate={{ rotate: 0, opacity: 1 }}
-                      exit={{ rotate: 90, opacity: 0 }}
-                    >
-                      <Moon size={20} />
-                    </motion.div>
-                  ) : (
-                    <motion.div
-                      key="sun"
-                      initial={{ rotate: 90, opacity: 0 }}
-                      animate={{ rotate: 0, opacity: 1 }}
-                      exit={{ rotate: -90, opacity: 0 }}
-                    >
-                      <Sun size={20} />
-                    </motion.div>
+              {license && authStatus === 'authenticated' && (
+                <div className="flex flex-col items-center sm:items-end text-xs text-gray-600 dark:text-gray-400">
+                  <span className="flex items-center gap-1 text-sm font-medium text-gray-700 dark:text-gray-200">
+                    <ShieldCheck className="h-4 w-4 text-indigo-500 dark:text-indigo-300" />
+                    Licensed to {license.owner}
+                  </span>
+                  {licenseExpiryText && (
+                    <span>Expires {licenseExpiryText}</span>
                   )}
-                </AnimatePresence>
-              </Button>
+                  {license.plan && (
+                    <span className="uppercase tracking-wide text-[10px] text-indigo-500 dark:text-indigo-300 mt-1">
+                      {license.plan} plan • ending in {license.licenseKeyLast4}
+                    </span>
+                  )}
+                </div>
+              )}
+
+              <div className="flex items-center gap-2">
+                {authStatus === 'authenticated' && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleSignOut}
+                    className="p-2 sm:px-3 sm:py-2"
+                  >
+                    <LogOut size={18} />
+                    <span className="hidden sm:inline ml-1">Sign out</span>
+                  </Button>
+                )}
+
+                {/* Dark Mode Toggle */}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setIsDarkMode(!isDarkMode)}
+                  className="p-2"
+                >
+                  <AnimatePresence mode="wait">
+                    {isDarkMode ? (
+                      <motion.div
+                        key="moon"
+                        initial={{ rotate: -90, opacity: 0 }}
+                        animate={{ rotate: 0, opacity: 1 }}
+                        exit={{ rotate: 90, opacity: 0 }}
+                      >
+                        <Moon size={20} />
+                      </motion.div>
+                    ) : (
+                      <motion.div
+                        key="sun"
+                        initial={{ rotate: 90, opacity: 0 }}
+                        animate={{ rotate: 0, opacity: 1 }}
+                        exit={{ rotate: -90, opacity: 0 }}
+                      >
+                        <Sun size={20} />
+                      </motion.div>
+                    )}
+                  </AnimatePresence>
+                </Button>
+              </div>
             </div>
           </motion.div>
         </header>
@@ -297,8 +509,8 @@ function App() {
                 answers={session.answers}
                 flaggedQuestions={session.flaggedQuestions}
                 summary={summary}
-                onRestart={() => startNewExamFromQA()}
-                onRetake={() => startNewExamFromQA()}
+                onRestart={() => { void handleStartNewExam(); }}
+                onRetake={() => { void handleStartNewExam(); }}
               />
             </motion.div>
           )}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,14 @@
 export type ChoiceKey = "A" | "B" | "C" | "D" | "E";
 
+export type AuthStatus = 'unknown' | 'loading' | 'authenticated' | 'unauthenticated' | 'expired';
+
+export interface LicenseInfo {
+  owner: string;
+  plan?: string;
+  expiresAt: string;
+  licenseKeyLast4: string;
+}
+
 export interface Choice {
   key: ChoiceKey;
   text: string;

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,6 +6,13 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 3000,
-    open: true
+    open: true,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:4000',
+        changeOrigin: true,
+        secure: false
+      }
+    }
   }
 })


### PR DESCRIPTION
## Summary
- add a lightweight Node licensing service that issues JWT-backed cookies and exposes login/session/logout endpoints
- extend the Zustand store and app UI to require server-validated licenses before starting or restarting exams
- surface license management controls in the header, add a dedicated sign-in overlay, update the proxy, and document the workflow

## Testing
- npm run build *(fails: pre-existing TypeScript errors in Builder/Exam/Review components and shared UI)*

------
https://chatgpt.com/codex/tasks/task_e_68cf06ebcd088329b53e4fdf7e3130f4