### PR TITLE
Add licensing backend with monitoring and frontend status banner

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,36 +1,235 @@
 import http from 'http';
-import { buildExamQuestionsResponse } from './routes/exams.js';
-import { HttpError, verifyLicense } from './middleware/licenseAuth.js';
+import { verifyLicense } from './middleware/licenseAuth.js';
+import { respondWithError } from './middleware/errorHandler.js';
+import type { LicenseContext } from './middleware/licenseAuth.js';
+import { handleExamQuestions } from './routes/exams.js';
+import { handleLicenseStatus, handleLicenseUsage } from './routes/licensing.js';
+import {
+  handleAdminCheckoutSession,
+  handleAdminGetLicense,
+  handleAdminIssueLicense,
+  handleAdminLicenseUsage,
+  handleAdminListLicenses,
+  handleAdminRenewLicense,
+  handleAdminRestoreLicense,
+  handleAdminRevokeLicense
+} from './routes/admin.js';
+import type { RequestContext } from './routes/types.js';
+import { initializeLicenseStore } from './services/licenseService.js';
+import { logRequest } from './utils/logger.js';
+import { getClientIp, readJsonBody, sendJson } from './utils/http.js';
+import { recordRateLimit, recordRequest, renderPrometheusMetrics } from './utils/metrics.js';
+import { checkRateLimit, getRateLimitReset } from './utils/rateLimiter.js';
+import { HttpError } from './middleware/licenseAuth.js';
+
+initializeLicenseStore();
 
 const allowedOrigins = buildOriginSet(process.env.CLIENT_ORIGINS);
 
+interface RouteExtras {
+  license?: LicenseContext;
+  seatId?: string;
+}
+
+type RouteHandler = (context: RequestContext, extras: RouteExtras) => Promise<void> | void;
+
+interface RouteDefinition {
+  method: string;
+  path: string;
+  handler: RouteHandler;
+  requireLicense?: boolean;
+  parseJson?: boolean;
+  rateLimit?: { windowMs: number; limit: number };
+}
+
+const DEFAULT_LIMIT = { windowMs: 60_000, limit: 60 } as const;
+const ADMIN_LIMIT = { windowMs: 60_000, limit: 30 } as const;
+const DOWNLOAD_LIMIT = { windowMs: 60_000, limit: 20 } as const;
+
+const routes: RouteDefinition[] = [
+  {
+    method: 'GET',
+    path: '/health',
+    handler: (context) => {
+      sendJson(context.res, 200, { status: 'ok' });
+    },
+    rateLimit: { windowMs: 30_000, limit: 30 }
+  },
+  {
+    method: 'GET',
+    path: '/metrics',
+    handler: (context) => {
+      const payload = renderPrometheusMetrics();
+      context.res.statusCode = 200;
+      context.res.setHeader('Content-Type', 'text/plain; version=0.0.4');
+      context.res.end(payload);
+    },
+    rateLimit: { windowMs: 15_000, limit: 10 }
+  },
+  {
+    method: 'GET',
+    path: '/api/exams/questions',
+    handler: (context, extras) => {
+      const license = extras.license;
+      const seatId = extras.seatId ?? license?.id ?? 'default-seat';
+      if (!license) {
+        throw new HttpError(401, 'A valid license token is required.');
+      }
+      return handleExamQuestions(context, license, seatId);
+    },
+    requireLicense: true,
+    rateLimit: DOWNLOAD_LIMIT
+  },
+  {
+    method: 'GET',
+    path: '/api/licensing/status',
+    handler: (context, extras) => {
+      if (!extras.license) {
+        throw new HttpError(401, 'License verification failed.');
+      }
+      handleLicenseStatus(context, extras.license);
+    },
+    requireLicense: true,
+    rateLimit: DEFAULT_LIMIT
+  },
+  {
+    method: 'GET',
+    path: '/api/licensing/usage',
+    handler: (context, extras) => {
+      if (!extras.license) {
+        throw new HttpError(401, 'License verification failed.');
+      }
+      handleLicenseUsage(context, extras.license);
+    },
+    requireLicense: true,
+    rateLimit: DEFAULT_LIMIT
+  },
+  {
+    method: 'GET',
+    path: '/api/admin/licenses',
+    handler: (context) => handleAdminListLicenses(context),
+    rateLimit: ADMIN_LIMIT
+  },
+  {
+    method: 'POST',
+    path: '/api/admin/licenses',
+    handler: (context) => handleAdminIssueLicense(context),
+    parseJson: true,
+    rateLimit: ADMIN_LIMIT
+  },
+  {
+    method: 'GET',
+    path: '/api/admin/licenses/:licenseId',
+    handler: (context) => handleAdminGetLicense(context),
+    rateLimit: ADMIN_LIMIT
+  },
+  {
+    method: 'POST',
+    path: '/api/admin/licenses/:licenseId/revoke',
+    handler: (context) => handleAdminRevokeLicense(context),
+    parseJson: true,
+    rateLimit: ADMIN_LIMIT
+  },
+  {
+    method: 'POST',
+    path: '/api/admin/licenses/:licenseId/restore',
+    handler: (context) => handleAdminRestoreLicense(context),
+    rateLimit: ADMIN_LIMIT
+  },
+  {
+    method: 'POST',
+    path: '/api/admin/licenses/:licenseId/renew',
+    handler: (context) => handleAdminRenewLicense(context),
+    parseJson: true,
+    rateLimit: ADMIN_LIMIT
+  },
+  {
+    method: 'GET',
+    path: '/api/admin/licenses/:licenseId/usage',
+    handler: (context) => handleAdminLicenseUsage(context),
+    rateLimit: ADMIN_LIMIT
+  },
+  {
+    method: 'POST',
+    path: '/api/admin/licenses/:licenseId/checkout',
+    handler: (context) => handleAdminCheckoutSession(context),
+    parseJson: true,
+    rateLimit: { windowMs: 60_000, limit: 10 }
+  }
+];
+
 export function createServer() {
   return http.createServer(async (req, res) => {
+    const start = Date.now();
+    const method = (req.method || 'GET').toUpperCase();
+    let matchedRoute: RouteDefinition | null = null;
+    let routePath = req.url ?? '/';
+
     try {
       applyCors(req, res);
 
-      if (req.method === 'OPTIONS') {
+      if (method === 'OPTIONS') {
         respondToPreflight(res);
         return;
       }
 
-      const requestUrl = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
-
-      if (req.method === 'GET' && requestUrl.pathname === '/health') {
-        sendJson(res, 200, { status: 'ok' });
+      const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
+      const match = findRoute(method, url.pathname);
+      if (!match) {
+        sendJson(res, 404, { error: 'NotFound', message: 'Resource not found.' });
         return;
       }
 
-      if (req.method === 'GET' && requestUrl.pathname === '/api/exams/questions') {
-        const license = verifyLicense(req.headers);
-        const payload = await buildExamQuestionsResponse(requestUrl.searchParams, license);
-        sendJson(res, 200, payload, { cacheControl: 'private, max-age=300' });
+      matchedRoute = match.route;
+      routePath = match.route.path;
+
+      const ip = getClientIp(req);
+      const rateLimitConfig = match.route.rateLimit ?? DEFAULT_LIMIT;
+      const limitKey = `${match.route.path}:${ip}`;
+      if (!checkRateLimit(limitKey, rateLimitConfig)) {
+        recordRateLimit();
+        const resetAt = getRateLimitReset(limitKey, rateLimitConfig.windowMs);
+        const retryAfterSeconds = Math.max(1, Math.ceil((resetAt - Date.now()) / 1000));
+        res.setHeader('Retry-After', String(retryAfterSeconds));
+        sendJson(res, 429, { error: 'RateLimited', message: 'Too many requests. Please slow down.' });
         return;
       }
 
-      sendJson(res, 404, { error: 'NotFound', message: 'Resource not found.' });
+      const context: RequestContext = {
+        req,
+        res,
+        url,
+        params: match.params,
+        query: url.searchParams
+      };
+
+      if (match.route.parseJson) {
+        try {
+          context.body = await readJsonBody(req);
+        } catch (error) {
+          throw new HttpError(400, error instanceof Error ? error.message : 'Invalid JSON payload.');
+        }
+      }
+
+      let license: LicenseContext | undefined;
+      let seatId: string | undefined;
+      if (match.route.requireLicense) {
+        license = verifyLicense(req.headers);
+        seatId = extractSeatId(req.headers, license.id);
+      }
+
+      await match.route.handler(context, { license, seatId });
     } catch (error) {
-      handleError(res, error);
+      respondWithError(res, error, routePath);
+    } finally {
+      const duration = Date.now() - start;
+      const statusCode = res.statusCode || 500;
+      const methodLabel = method;
+      const routeLabel = matchedRoute ? matchedRoute.path : routePath;
+      recordRequest(methodLabel, routeLabel, statusCode, duration);
+      logRequest(methodLabel, routeLabel, statusCode, duration, {
+        ip: getClientIp(req)
+      });
     }
   });
 }
@@ -50,88 +249,94 @@ export default createServer;
 
 function applyCors(req: http.IncomingMessage, res: http.ServerResponse) {
   res.setHeader('Vary', 'Origin');
-
   const originHeader = req.headers.origin;
   const origin = Array.isArray(originHeader) ? originHeader[0] : originHeader;
   if (!origin) {
     return;
   }
-
   if (allowedOrigins.size > 0 && !allowedOrigins.has(origin)) {
     throw new HttpError(403, 'Origin not allowed by CORS policy.');
   }
-
   res.setHeader('Access-Control-Allow-Origin', origin);
   res.setHeader('Access-Control-Allow-Credentials', 'true');
 }
 
 function respondToPreflight(res: http.ServerResponse) {
   res.statusCode = 204;
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Authorization, X-License-Token, Content-Type');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Authorization, X-License-Token, X-Seat-Id, X-Admin-Token, Content-Type');
   res.setHeader('Access-Control-Max-Age', '86400');
   res.end();
 }
 
-function sendJson(
-  res: http.ServerResponse,
-  status: number,
-  body: unknown,
-  options: { cacheControl?: string } = {}
-) {
-  if (res.headersSent) {
-    return;
+function findRoute(method: string, pathname: string): { route: RouteDefinition; params: Record<string, string> } | null {
+  for (const route of routes) {
+    if (route.method !== method) {
+      continue;
+    }
+    const params = matchPath(route.path, pathname);
+    if (params) {
+      return { route, params };
+    }
   }
-
-  const payload = JSON.stringify(body);
-  res.statusCode = status;
-  res.setHeader('Content-Type', 'application/json; charset=utf-8');
-  res.setHeader('Content-Length', Buffer.byteLength(payload));
-
-  if (options.cacheControl) {
-    res.setHeader('Cache-Control', options.cacheControl);
-  } else if (status >= 400) {
-    res.setHeader('Cache-Control', 'no-store');
-  }
-
-  res.end(payload);
+  return null;
 }
 
-function handleError(res: http.ServerResponse, error: unknown) {
-  if (res.headersSent) {
-    res.end();
-    return;
+function matchPath(routePath: string, actualPath: string): Record<string, string> | null {
+  const cleanRoute = normalizePath(routePath);
+  const cleanActual = normalizePath(actualPath);
+  const routeParts = cleanRoute.split('/');
+  const actualParts = cleanActual.split('/');
+
+  if (routeParts.length !== actualParts.length) {
+    return null;
   }
 
-  let status = 500;
-  let message = 'Unexpected server error.';
-  let code = 'ServerError';
-
-  if (error instanceof HttpError) {
-    status = error.status;
-    message = error.message;
-    code = status === 401 || status === 403 ? 'LicenseVerificationFailed' : 'ServerError';
-  } else if (error instanceof Error) {
-    message = error.message || message;
+  const params: Record<string, string> = {};
+  for (let index = 0; index < routeParts.length; index += 1) {
+    const routePart = routeParts[index];
+    const actualPart = actualParts[index];
+    if (routePart.startsWith(':')) {
+      const key = routePart.slice(1);
+      params[key] = decodeURIComponent(actualPart);
+      continue;
+    }
+    if (routePart !== actualPart) {
+      return null;
+    }
   }
+  return params;
+}
 
-  if (process.env.NODE_ENV !== 'test') {
-    // eslint-disable-next-line no-console
-    console.error(error);
+function normalizePath(pathname: string): string {
+  const trimmed = pathname.replace(/\/+$/, '');
+  if (!trimmed) {
+    return '';
   }
+  return trimmed.startsWith('/') ? trimmed.slice(1) : trimmed;
+}
 
-  sendJson(res, status, { error: code, message });
+function extractSeatId(headers: http.IncomingHttpHeaders, fallback: string): string {
+  const seatHeader = headers['x-seat-id'] || headers['x-license-seat'];
+  if (Array.isArray(seatHeader)) {
+    for (const entry of seatHeader) {
+      if (entry && entry.trim()) {
+        return entry.trim();
+      }
+    }
+  } else if (typeof seatHeader === 'string' && seatHeader.trim()) {
+    return seatHeader.trim();
+  }
+  return `${fallback}-seat`;
 }
 
 function buildOriginSet(value: string | undefined): Set<string> {
   if (!value) {
     return new Set(['http://localhost:5173', 'http://127.0.0.1:5173']);
   }
-
   const entries = value
     .split(',')
     .map((entry) => entry.trim())
     .filter((entry) => entry.length > 0);
-
   return new Set(entries);
 }

--- a/server/middleware/adminAuth.ts
+++ b/server/middleware/adminAuth.ts
@@ -1,0 +1,21 @@
+import { HttpError } from './licenseAuth.js';
+
+const ADMIN_TOKEN = process.env.ADMIN_API_KEY?.trim();
+
+export function requireAdmin(headers: Record<string, string | string[] | undefined>): void {
+  if (!ADMIN_TOKEN) {
+    throw new HttpError(500, 'Admin access token is not configured.');
+  }
+  const provided = extractHeader(headers, 'x-admin-token');
+  if (!provided || provided !== ADMIN_TOKEN) {
+    throw new HttpError(401, 'Admin authorization is required for this endpoint.');
+  }
+}
+
+function extractHeader(headers: Record<string, string | string[] | undefined>, name: string): string | undefined {
+  const raw = headers[name];
+  if (Array.isArray(raw)) {
+    return raw[0];
+  }
+  return typeof raw === 'string' ? raw : undefined;
+}

--- a/server/middleware/errorHandler.ts
+++ b/server/middleware/errorHandler.ts
@@ -1,0 +1,25 @@
+import http from 'http';
+import { HttpError } from './licenseAuth.js';
+import { logError } from '../utils/logger.js';
+
+export function respondWithError(res: http.ServerResponse, error: unknown, route: string): void {
+  if (res.headersSent) {
+    res.end();
+    return;
+  }
+
+  if (error instanceof HttpError) {
+    res.statusCode = error.status;
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    res.setHeader('Cache-Control', 'no-store');
+    res.end(JSON.stringify({ error: error.status >= 500 ? 'ServerError' : 'RequestError', message: error.message }));
+    return;
+  }
+
+  logError(error, { route });
+  res.statusCode = 500;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.setHeader('Cache-Control', 'no-store');
+  const message = error instanceof Error ? error.message : 'Unexpected error';
+  res.end(JSON.stringify({ error: 'ServerError', message }));
+}

--- a/server/node-shim.d.ts
+++ b/server/node-shim.d.ts
@@ -7,6 +7,11 @@ declare module 'http' {
     headers: IncomingHttpHeaders;
     method?: string;
     url?: string | undefined;
+    socket?: {
+      remoteAddress?: string;
+    };
+    on(event: string, handler: (...args: unknown[]) => void): void;
+    [Symbol.asyncIterator](): AsyncIterableIterator<string | Uint8Array>;
   }
 
   interface ServerResponse {
@@ -33,8 +38,18 @@ declare module 'crypto' {
 
   function createHmac(algorithm: string, key: string): Hmac;
   function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean;
+  function randomUUID(): string;
 
   export { createHmac, timingSafeEqual };
+}
+
+declare module 'fs' {
+  function appendFileSync(path: string, data: string, encoding: string): void;
+  function writeFileSync(path: string, data: string, encoding: string): void;
+  function readFileSync(path: string, encoding: string): string;
+  function existsSync(path: string): boolean;
+  function mkdirSync(path: string, options: { recursive: boolean }): void;
+  export { appendFileSync, writeFileSync, readFileSync, existsSync, mkdirSync };
 }
 
 declare module 'fs/promises' {
@@ -44,12 +59,16 @@ declare module 'fs/promises' {
 
 declare module 'path' {
   function resolve(...parts: string[]): string;
-  export { resolve };
+  function join(...parts: string[]): string;
+  function dirname(path: string): string;
+  export { resolve, join, dirname };
 }
 
 declare const Buffer: {
   from(data: string, encoding?: string): Buffer;
+  from(data: Uint8Array): Buffer;
   byteLength(data: string): number;
+  concat(chunks: Uint8Array[]): Buffer;
 };
 
 declare interface Buffer extends Uint8Array {

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -1,0 +1,134 @@
+import { requireAdmin } from '../middleware/adminAuth.js';
+import { HttpError, signLicenseToken } from '../middleware/licenseAuth.js';
+import {
+  getLicenseSummary,
+  getUsageSummary,
+  issueLicense,
+  listLicenses,
+  renewLicense,
+  restoreLicense,
+  revokeLicense
+} from '../services/licenseService.js';
+import type { IssueLicenseInput } from '../services/licenseService.js';
+import { createCheckoutSession } from '../services/paymentService.js';
+import { sendJson } from '../utils/http.js';
+import type { RequestContext } from './types.js';
+
+export function handleAdminListLicenses(context: RequestContext): void {
+  requireAdmin(normalizeHeaders(context.req.headers));
+  const licenses = listLicenses();
+  sendJson(context.res, 200, { licenses }, { cacheControl: 'no-store' });
+}
+
+export function handleAdminIssueLicense(context: RequestContext): void {
+  requireAdmin(normalizeHeaders(context.req.headers));
+  const body = parseBody<IssueLicenseInput & { issueToken?: boolean; tokenExpirySeconds?: number }>(context.body);
+  const summary = issueLicense(body);
+  let token: string | undefined;
+  let tokenExpiresAt: string | undefined;
+  if (body.issueToken !== false) {
+    const expiresInSeconds = body.tokenExpirySeconds ?? 60 * 60 * 24 * 30;
+    token = signLicenseToken({
+      licenseId: summary.licenseId,
+      status: summary.status,
+      tier: summary.tier,
+      name: summary.ownerName
+    }, { expiresInSeconds });
+    tokenExpiresAt = new Date(Date.now() + expiresInSeconds * 1000).toISOString();
+  }
+  sendJson(context.res, 201, { license: summary, token, tokenExpiresAt }, { cacheControl: 'no-store' });
+}
+
+export function handleAdminGetLicense(context: RequestContext): void {
+  requireAdmin(normalizeHeaders(context.req.headers));
+  const licenseId = context.params.licenseId;
+  if (!licenseId) {
+    throw new HttpError(400, 'License identifier is required.');
+  }
+  const summary = getLicenseSummary(licenseId);
+  sendJson(context.res, 200, { license: summary }, { cacheControl: 'no-store' });
+}
+
+export function handleAdminRevokeLicense(context: RequestContext): void {
+  requireAdmin(normalizeHeaders(context.req.headers));
+  const licenseId = context.params.licenseId;
+  if (!licenseId) {
+    throw new HttpError(400, 'License identifier is required.');
+  }
+  const body = parseBody<{ reason?: string }>(context.body);
+  const summary = revokeLicense(licenseId, body?.reason);
+  sendJson(context.res, 200, { license: summary }, { cacheControl: 'no-store' });
+}
+
+export function handleAdminRestoreLicense(context: RequestContext): void {
+  requireAdmin(normalizeHeaders(context.req.headers));
+  const licenseId = context.params.licenseId;
+  if (!licenseId) {
+    throw new HttpError(400, 'License identifier is required.');
+  }
+  const summary = restoreLicense(licenseId);
+  sendJson(context.res, 200, { license: summary }, { cacheControl: 'no-store' });
+}
+
+export function handleAdminRenewLicense(context: RequestContext): void {
+  requireAdmin(normalizeHeaders(context.req.headers));
+  const licenseId = context.params.licenseId;
+  if (!licenseId) {
+    throw new HttpError(400, 'License identifier is required.');
+  }
+  const body = parseBody<{ expiresAt: string; renewalReminderAt?: string }>(context.body);
+  const summary = renewLicense(licenseId, {
+    expiresAt: body?.expiresAt ?? '',
+    renewalReminderAt: body?.renewalReminderAt
+  });
+  sendJson(context.res, 200, { license: summary }, { cacheControl: 'no-store' });
+}
+
+export async function handleAdminLicenseUsage(context: RequestContext): Promise<void> {
+  requireAdmin(normalizeHeaders(context.req.headers));
+  const licenseId = context.params.licenseId;
+  if (!licenseId) {
+    throw new HttpError(400, 'License identifier is required.');
+  }
+  const summary = getLicenseSummary(licenseId);
+  const usage = getUsageSummary(licenseId);
+  sendJson(context.res, 200, { license: summary, usage }, { cacheControl: 'no-store' });
+}
+
+export async function handleAdminCheckoutSession(context: RequestContext): Promise<void> {
+  requireAdmin(normalizeHeaders(context.req.headers));
+  const licenseId = context.params.licenseId;
+  if (!licenseId) {
+    throw new HttpError(400, 'License identifier is required.');
+  }
+  const body = parseBody<{ successUrl: string; cancelUrl: string; priceId?: string; quantity?: number; customerEmail?: string; mode?: 'payment' | 'subscription' }>(context.body);
+  if (!body?.successUrl || !body.cancelUrl) {
+    throw new HttpError(400, 'Both successUrl and cancelUrl are required.');
+  }
+
+  const session = await createCheckoutSession({
+    licenseId,
+    successUrl: body.successUrl,
+    cancelUrl: body.cancelUrl,
+    priceId: body.priceId,
+    quantity: body.quantity,
+    customerEmail: body.customerEmail,
+    mode: body.mode
+  });
+  sendJson(context.res, 201, { session }, { cacheControl: 'no-store' });
+}
+
+function normalizeHeaders(headers: RequestContext['req']['headers']): Record<string, string | string[] | undefined> {
+  const normalized: Record<string, string | string[] | undefined> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    normalized[key.toLowerCase()] = value;
+  }
+  return normalized;
+}
+
+function parseBody<T>(body: unknown): T {
+  if (typeof body !== 'object' || body === null) {
+    throw new HttpError(400, 'A JSON body is required for this endpoint.');
+  }
+  return body as T;
+}

--- a/server/routes/exams.ts
+++ b/server/routes/exams.ts
@@ -1,5 +1,9 @@
 import type { LicenseContext } from '../middleware/licenseAuth.js';
+import { assertLicenseActive, ensureSeatAssignment, recordUsage } from '../services/licenseService.js';
 import { getQuestionPayload } from '../services/questionService.js';
+import { recordLicenseDownload } from '../utils/metrics.js';
+import { sendJson } from '../utils/http.js';
+import type { RequestContext } from './types.js';
 
 const REFRESH_VALUES = new Set(['1', 'true', 'yes']);
 
@@ -7,27 +11,55 @@ export interface ExamQuestionsResponse {
   questions: Awaited<ReturnType<typeof getQuestionPayload>>['questions'];
   version: string;
   updatedAt: string;
-  licensedTo?: {
+  licensedTo: {
     id: string;
     status: string;
+    seatsTotal: number;
+    seatsUsed: number;
+    seatsRemaining: number;
+    tier?: string;
+    expiresAt?: string;
+    renewalReminderAt?: string;
+    renewalMessage?: string;
   };
 }
 
-export async function buildExamQuestionsResponse(
-  query: URLSearchParams,
-  license: LicenseContext
-): Promise<ExamQuestionsResponse> {
-  const refreshParam = query.get('refresh');
+export async function handleExamQuestions(
+  context: RequestContext,
+  license: LicenseContext,
+  seatId: string
+): Promise<void> {
+  const refreshParam = context.query.get('refresh');
   const forceRefresh = refreshParam ? REFRESH_VALUES.has(refreshParam.toLowerCase()) : false;
+
+  const summary = assertLicenseActive(license.id);
+  const seatSnapshot = ensureSeatAssignment(summary.licenseId, seatId, license.name);
   const payload = await getQuestionPayload(forceRefresh);
 
-  return {
+  const clientIp = context.req.socket?.remoteAddress ?? 'unknown';
+  recordUsage(summary.licenseId, 'questions.download', {
+    ip: clientIp,
+    userAgent: context.req.headers['user-agent'],
+    seatId
+  }, seatId);
+  recordLicenseDownload(summary.licenseId);
+
+  const response: ExamQuestionsResponse = {
     questions: payload.questions,
     version: payload.version,
     updatedAt: payload.updatedAt,
     licensedTo: {
-      id: license.id,
-      status: license.status
+      id: summary.licenseId,
+      status: summary.status,
+      seatsTotal: summary.seatsTotal,
+      seatsUsed: seatSnapshot.seatsUsed,
+      seatsRemaining: seatSnapshot.seatsRemaining,
+      tier: summary.tier,
+      expiresAt: summary.expiresAt,
+      renewalReminderAt: summary.renewalReminderAt,
+      renewalMessage: summary.renewalMessage
     }
   };
+
+  sendJson(context.res, 200, response, { cacheControl: 'private, max-age=120' });
 }

--- a/server/routes/licensing.ts
+++ b/server/routes/licensing.ts
@@ -1,0 +1,19 @@
+import type { LicenseContext } from '../middleware/licenseAuth.js';
+import { assertLicenseActive, getLicenseSummary, getUsageSummary } from '../services/licenseService.js';
+import { sendJson } from '../utils/http.js';
+import type { RequestContext } from './types.js';
+
+export function handleLicenseStatus(context: RequestContext, license: LicenseContext): void {
+  const summary = getLicenseSummary(license.id);
+  sendJson(context.res, 200, {
+    license: summary,
+    active: summary.status === 'active' || summary.status === 'trial',
+    needsRenewal: summary.status === 'expired'
+  }, { cacheControl: 'no-store' });
+}
+
+export function handleLicenseUsage(context: RequestContext, license: LicenseContext): void {
+  const summary = assertLicenseActive(license.id);
+  const usage = getUsageSummary(summary.licenseId);
+  sendJson(context.res, 200, { summary, usage }, { cacheControl: 'no-store' });
+}

--- a/server/routes/types.ts
+++ b/server/routes/types.ts
@@ -1,0 +1,10 @@
+import http from 'http';
+
+export interface RequestContext {
+  req: http.IncomingMessage;
+  res: http.ServerResponse;
+  url: URL;
+  params: Record<string, string>;
+  query: URLSearchParams;
+  body?: unknown;
+}

--- a/server/services/licenseService.ts
+++ b/server/services/licenseService.ts
@@ -1,0 +1,376 @@
+import { HttpError } from '../middleware/licenseAuth.js';
+import {
+  getDatabase,
+  initDatabase,
+  updateDatabase
+} from '../storage/database.js';
+import type {
+  DatabaseSchema,
+  LicenseRecord,
+  LicenseSeatRecord,
+  LicenseStatus,
+  UsageRecord,
+  UserRecord
+} from '../storage/database.js';
+import { log } from '../utils/logger.js';
+
+export interface LicenseSummary {
+  licenseId: string;
+  status: LicenseStatus;
+  seatsTotal: number;
+  seatsUsed: number;
+  seatsRemaining: number;
+  expiresAt?: string;
+  renewalReminderAt?: string;
+  revokedAt?: string;
+  tier?: string;
+  ownerName?: string;
+  ownerEmail?: string;
+  lastUsageAt?: string;
+  totalDownloads: number;
+  renewalMessage?: string;
+}
+
+export interface IssueLicenseInput {
+  licenseId?: string;
+  seats: number;
+  status?: LicenseStatus;
+  tier?: string;
+  expiresAt?: string;
+  renewalReminderAt?: string;
+  userEmail: string;
+  userName?: string;
+  notes?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface RenewLicenseInput {
+  expiresAt: string;
+  renewalReminderAt?: string;
+}
+
+export interface LicenseUsageSummary {
+  totalEvents: number;
+  downloadsLast30Days: number;
+  recent: UsageRecord[];
+}
+
+export function initializeLicenseStore(): void {
+  initDatabase();
+  seedDemoLicense();
+}
+
+export function listLicenses(): LicenseSummary[] {
+  const database = getDatabase();
+  return database.licenses.map((license) => buildLicenseSummary(database, license));
+}
+
+export function getLicenseSummary(licenseId: string): LicenseSummary {
+  const database = getDatabase();
+  const license = database.licenses.find((entry) => entry.id === licenseId);
+  if (!license) {
+    throw new HttpError(404, 'License not found.');
+  }
+  return buildLicenseSummary(database, license);
+}
+
+export function issueLicense(input: IssueLicenseInput): LicenseSummary {
+  if (!input.userEmail || !input.userEmail.includes('@')) {
+    throw new HttpError(400, 'A valid user email is required to issue a license.');
+  }
+  if (!Number.isFinite(input.seats) || input.seats <= 0) {
+    throw new HttpError(400, 'Licenses must have at least one seat.');
+  }
+
+  const licenseId = (input.licenseId || generateLicenseId()).trim();
+  return updateDatabase((database) => {
+    const existing = database.licenses.find((item) => item.id === licenseId);
+    if (existing) {
+      throw new HttpError(409, 'A license with this identifier already exists.');
+    }
+
+    const user = upsertUser(database, input.userEmail, input.userName);
+    const now = new Date().toISOString();
+    const record: LicenseRecord = {
+      id: licenseId,
+      userId: user.id,
+      status: input.status ?? 'active',
+      seatsTotal: Math.max(1, Math.floor(input.seats)),
+      seatsInUse: 0,
+      tier: input.tier,
+      createdAt: now,
+      updatedAt: now,
+      expiresAt: input.expiresAt,
+      renewalReminderAt: input.renewalReminderAt,
+      notes: input.notes,
+      metadata: input.metadata
+    };
+
+    database.licenses.push(record);
+    log('info', 'Issued new license', { licenseId: record.id, userEmail: user.email });
+    return buildLicenseSummary(database, record);
+  });
+}
+
+export function renewLicense(licenseId: string, input: RenewLicenseInput): LicenseSummary {
+  if (!input.expiresAt) {
+    throw new HttpError(400, 'The new expiration date is required.');
+  }
+
+  return updateDatabase((database) => {
+    const license = database.licenses.find((entry) => entry.id === licenseId);
+    if (!license) {
+      throw new HttpError(404, 'License not found.');
+    }
+
+    license.expiresAt = input.expiresAt;
+    license.renewalReminderAt = input.renewalReminderAt;
+    license.updatedAt = new Date().toISOString();
+    if (license.status === 'expired') {
+      license.status = 'active';
+    }
+
+    log('info', 'Renewed license', { licenseId });
+    return buildLicenseSummary(database, license);
+  });
+}
+
+export function revokeLicense(licenseId: string, reason?: string): LicenseSummary {
+  return updateDatabase((database) => {
+    const license = database.licenses.find((entry) => entry.id === licenseId);
+    if (!license) {
+      throw new HttpError(404, 'License not found.');
+    }
+
+    license.status = 'revoked';
+    license.revokedAt = new Date().toISOString();
+    license.updatedAt = license.revokedAt;
+    if (reason) {
+      license.notes = reason;
+    }
+
+    log('warn', 'License revoked', { licenseId, reason });
+    return buildLicenseSummary(database, license);
+  });
+}
+
+export function restoreLicense(licenseId: string): LicenseSummary {
+  return updateDatabase((database) => {
+    const license = database.licenses.find((entry) => entry.id === licenseId);
+    if (!license) {
+      throw new HttpError(404, 'License not found.');
+    }
+
+    license.status = 'active';
+    license.revokedAt = undefined;
+    license.updatedAt = new Date().toISOString();
+
+    log('info', 'License restored', { licenseId });
+    return buildLicenseSummary(database, license);
+  });
+}
+
+export function recordUsage(
+  licenseId: string,
+  event: string,
+  details: Record<string, unknown> = {},
+  seatId?: string
+): void {
+  const now = new Date().toISOString();
+  updateDatabase((database) => {
+    const license = database.licenses.find((entry) => entry.id === licenseId);
+    if (!license) {
+      throw new HttpError(404, 'License not found.');
+    }
+    const usage: UsageRecord = {
+      id: createIdentifier('usage', 6),
+      licenseId,
+      event,
+      createdAt: now,
+      seatId,
+      details
+    };
+    database.usage.push(usage);
+    license.updatedAt = now;
+  });
+}
+
+export function ensureSeatAssignment(
+  licenseId: string,
+  seatId: string,
+  seatLabel?: string
+): { seatsUsed: number; seatsRemaining: number } {
+  const normalizedSeat = seatId.trim() || 'default-seat';
+  return updateDatabase((database) => {
+    const license = database.licenses.find((entry) => entry.id === licenseId);
+    if (!license) {
+      throw new HttpError(404, 'License not found.');
+    }
+
+    let seat = database.seats.find((entry) => entry.licenseId === licenseId && entry.seatId === normalizedSeat);
+    const now = new Date().toISOString();
+
+    if (!seat) {
+      if (license.seatsInUse >= license.seatsTotal) {
+        throw new HttpError(403, 'All seats for this license are already allocated.');
+      }
+      seat = {
+        licenseId,
+        seatId: normalizedSeat,
+        assignedTo: seatLabel,
+        firstSeenAt: now,
+        lastSeenAt: now
+      } satisfies LicenseSeatRecord;
+      database.seats.push(seat);
+      license.seatsInUse += 1;
+    } else {
+      seat.lastSeenAt = now;
+      if (seatLabel && seatLabel !== seat.assignedTo) {
+        seat.assignedTo = seatLabel;
+      }
+    }
+
+    license.updatedAt = now;
+    return {
+      seatsUsed: license.seatsInUse,
+      seatsRemaining: Math.max(0, license.seatsTotal - license.seatsInUse)
+    };
+  });
+}
+
+export function assertLicenseActive(licenseId: string): LicenseSummary {
+  const summary = getLicenseSummary(licenseId);
+  if (summary.status === 'revoked') {
+    throw new HttpError(403, 'This license has been revoked.');
+  }
+  if (summary.status === 'expired') {
+    throw new HttpError(403, 'This license is expired. Please renew to regain access.');
+  }
+  return summary;
+}
+
+export function getUsageSummary(licenseId: string): LicenseUsageSummary {
+  const database = getDatabase();
+  const now = Date.now();
+  const thirtyDaysAgo = now - 30 * 24 * 60 * 60 * 1000;
+  const relevant = database.usage.filter((entry) => entry.licenseId === licenseId);
+  const downloadsLast30Days = relevant.filter((entry) => entry.event === 'questions.download' && new Date(entry.createdAt).getTime() >= thirtyDaysAgo).length;
+  const recent = relevant.slice(-25).reverse();
+  return {
+    totalEvents: relevant.length,
+    downloadsLast30Days,
+    recent
+  };
+}
+
+function buildLicenseSummary(database: DatabaseSchema, license: LicenseRecord): LicenseSummary {
+  const user = database.users.find((entry) => entry.id === license.userId);
+  const usage = database.usage.filter((entry) => entry.licenseId === license.id);
+  const totalDownloads = usage.filter((entry) => entry.event === 'questions.download').length;
+  const lastUsageAt = usage.length > 0 ? usage[usage.length - 1].createdAt : undefined;
+  let status = license.status;
+
+  if (license.expiresAt) {
+    const expiresAtMs = new Date(license.expiresAt).getTime();
+    if (Number.isFinite(expiresAtMs) && expiresAtMs < Date.now() && status !== 'revoked') {
+      status = 'expired';
+    }
+  }
+
+  let renewalMessage: string | undefined;
+  if (status === 'expired') {
+    renewalMessage = 'Your license has expired. Renew to continue receiving exam updates.';
+  } else if (license.expiresAt) {
+    const diff = new Date(license.expiresAt).getTime() - Date.now();
+    const days = Math.ceil(diff / (1000 * 60 * 60 * 24));
+    if (Number.isFinite(days) && days <= 14) {
+      renewalMessage = `License expires in ${days} day${days === 1 ? '' : 's'}.`;
+    }
+  }
+
+  return {
+    licenseId: license.id,
+    status,
+    seatsTotal: license.seatsTotal,
+    seatsUsed: license.seatsInUse,
+    seatsRemaining: Math.max(0, license.seatsTotal - license.seatsInUse),
+    expiresAt: license.expiresAt,
+    renewalReminderAt: license.renewalReminderAt,
+    revokedAt: license.revokedAt,
+    tier: license.tier,
+    ownerName: user?.name,
+    ownerEmail: user?.email,
+    lastUsageAt,
+    totalDownloads,
+    renewalMessage
+  };
+}
+
+function upsertUser(database: DatabaseSchema, email: string, name?: string): UserRecord {
+  const normalizedEmail = email.trim().toLowerCase();
+  let user = database.users.find((entry) => entry.email === normalizedEmail);
+  const now = new Date().toISOString();
+
+  if (!user) {
+    user = {
+      id: createIdentifier('user', 6),
+      email: normalizedEmail,
+      name: name?.trim(),
+      createdAt: now,
+      updatedAt: now
+    } satisfies UserRecord;
+    database.users.push(user);
+  } else {
+    if (name && name.trim() && name.trim() !== (user.name ?? '')) {
+      user.name = name.trim();
+      user.updatedAt = now;
+    }
+  }
+
+  return user;
+}
+
+function generateLicenseId(): string {
+  return createIdentifier('lic', 8);
+}
+
+function createIdentifier(prefix: string, randomLength = 8): string {
+  return `${prefix}_${Date.now().toString(36)}${randomString(randomLength)}`;
+}
+
+function randomString(length: number): string {
+  const alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  let output = '';
+  for (let index = 0; index < length; index += 1) {
+    const randomIndex = Math.floor(Math.random() * alphabet.length);
+    output += alphabet[randomIndex];
+  }
+  return output;
+}
+
+function seedDemoLicense(): void {
+  updateDatabase((database) => {
+    if (database.licenses.some((license) => license.id === 'demo-license')) {
+      return;
+    }
+
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000).toISOString();
+    const user = upsertUser(database, 'demo@example.com', 'Demo Account');
+    const record: LicenseRecord = {
+      id: 'demo-license',
+      userId: user.id,
+      status: 'trial',
+      seatsTotal: 3,
+      seatsInUse: 0,
+      tier: 'trial',
+      createdAt: now.toISOString(),
+      updatedAt: now.toISOString(),
+      expiresAt,
+      renewalReminderAt: new Date(now.getTime() + 20 * 24 * 60 * 60 * 1000).toISOString(),
+      notes: 'Auto-generated demo license'
+    };
+    database.licenses.push(record);
+    log('info', 'Seeded demo license', { licenseId: record.id });
+  });
+}

--- a/server/services/paymentService.ts
+++ b/server/services/paymentService.ts
@@ -1,0 +1,74 @@
+import { HttpError } from '../middleware/licenseAuth.js';
+import { log, logError } from '../utils/logger.js';
+
+const STRIPE_SECRET = process.env.STRIPE_SECRET_KEY?.trim();
+const DEFAULT_PRICE = process.env.STRIPE_PRICE_ID?.trim();
+
+export interface CheckoutSessionInput {
+  licenseId: string;
+  successUrl: string;
+  cancelUrl: string;
+  priceId?: string;
+  customerEmail?: string;
+  quantity?: number;
+  mode?: 'payment' | 'subscription';
+}
+
+export interface CheckoutSessionResponse {
+  id: string;
+  url?: string;
+}
+
+export async function createCheckoutSession(
+  input: CheckoutSessionInput
+): Promise<CheckoutSessionResponse> {
+  if (!STRIPE_SECRET) {
+    throw new HttpError(500, 'Stripe integration is not configured.');
+  }
+
+  const priceId = (input.priceId || DEFAULT_PRICE || '').trim();
+  if (!priceId) {
+    throw new HttpError(400, 'A Stripe price ID must be provided.');
+  }
+
+  const params = new URLSearchParams();
+  params.set('mode', input.mode ?? 'payment');
+  params.set('success_url', input.successUrl);
+  params.set('cancel_url', input.cancelUrl);
+  params.set('line_items[0][price]', priceId);
+  params.set('line_items[0][quantity]', String(input.quantity ?? 1));
+  params.set('metadata[licenseId]', input.licenseId);
+  if (input.customerEmail) {
+    params.set('customer_email', input.customerEmail);
+  }
+
+  try {
+    const response = await fetch('https://api.stripe.com/v1/checkout/sessions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${STRIPE_SECRET}`,
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: params.toString()
+    });
+
+    const data = await response.json() as { id?: string; url?: string; error?: { message?: string } };
+    if (!response.ok) {
+      const message = data.error?.message || 'Unable to create Stripe checkout session.';
+      throw new HttpError(response.status, message);
+    }
+
+    if (!data.id) {
+      throw new HttpError(502, 'Stripe did not return a checkout session identifier.');
+    }
+
+    log('info', 'Created Stripe checkout session', { licenseId: input.licenseId, sessionId: data.id });
+    return { id: data.id, url: data.url };
+  } catch (error) {
+    logError(error, { licenseId: input.licenseId, scope: 'stripe.checkout' });
+    if (error instanceof HttpError) {
+      throw error;
+    }
+    throw new HttpError(502, 'Unexpected error while talking to Stripe.');
+  }
+}

--- a/server/storage/database.ts
+++ b/server/storage/database.ts
@@ -1,0 +1,122 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface UserRecord {
+  id: string;
+  email: string;
+  name?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type LicenseStatus = 'active' | 'trial' | 'revoked' | 'expired';
+
+export interface LicenseRecord {
+  id: string;
+  userId: string;
+  status: LicenseStatus;
+  seatsTotal: number;
+  seatsInUse: number;
+  tier?: string;
+  createdAt: string;
+  updatedAt: string;
+  expiresAt?: string;
+  renewalReminderAt?: string;
+  revokedAt?: string;
+  notes?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface LicenseSeatRecord {
+  licenseId: string;
+  seatId: string;
+  assignedTo?: string;
+  firstSeenAt: string;
+  lastSeenAt: string;
+}
+
+export interface UsageRecord {
+  id: string;
+  licenseId: string;
+  event: string;
+  createdAt: string;
+  seatId?: string;
+  details?: Record<string, unknown>;
+}
+
+export interface DatabaseSchema {
+  users: UserRecord[];
+  licenses: LicenseRecord[];
+  seats: LicenseSeatRecord[];
+  usage: UsageRecord[];
+}
+
+const DEFAULT_DATA: DatabaseSchema = {
+  users: [],
+  licenses: [],
+  seats: [],
+  usage: []
+};
+
+let dataCache: DatabaseSchema | undefined;
+let dbPath: string | undefined;
+
+function resolveDatabasePath(): string {
+  if (dbPath) {
+    return dbPath;
+  }
+
+  const configured = process.env.LICENSE_DB_PATH ? process.env.LICENSE_DB_PATH.trim() : '';
+  const targetPath = configured || path.join(process.cwd(), 'data', 'license-db.json');
+  const directory = path.dirname(targetPath);
+  fs.mkdirSync(directory, { recursive: true });
+  dbPath = targetPath;
+  return targetPath;
+}
+
+export function initDatabase(): DatabaseSchema {
+  const filePath = resolveDatabasePath();
+  if (!fs.existsSync(filePath)) {
+    fs.writeFileSync(filePath, JSON.stringify(DEFAULT_DATA, null, 2), 'utf8');
+    dataCache = JSON.parse(JSON.stringify(DEFAULT_DATA)) as DatabaseSchema;
+    return dataCache;
+  }
+
+  const raw = fs.readFileSync(filePath, 'utf8');
+  try {
+    const parsed = JSON.parse(raw) as DatabaseSchema;
+    dataCache = {
+      users: Array.isArray(parsed.users) ? parsed.users : [],
+      licenses: Array.isArray(parsed.licenses) ? parsed.licenses : [],
+      seats: Array.isArray(parsed.seats) ? parsed.seats : [],
+      usage: Array.isArray(parsed.usage) ? parsed.usage : []
+    };
+  } catch (error) {
+    fs.writeFileSync(filePath, JSON.stringify(DEFAULT_DATA, null, 2), 'utf8');
+    dataCache = JSON.parse(JSON.stringify(DEFAULT_DATA)) as DatabaseSchema;
+  }
+
+  return dataCache;
+}
+
+export function getDatabase(): DatabaseSchema {
+  if (!dataCache) {
+    return initDatabase();
+  }
+  return dataCache;
+}
+
+export function saveDatabase(): void {
+  if (!dataCache) {
+    return;
+  }
+  const filePath = resolveDatabasePath();
+  fs.writeFileSync(filePath, JSON.stringify(dataCache, null, 2), 'utf8');
+}
+
+export function updateDatabase<T>(mutator: (database: DatabaseSchema) => T): T {
+  const database = getDatabase();
+  const result = mutator(database);
+  saveDatabase();
+  return result;
+}

--- a/server/utils/http.ts
+++ b/server/utils/http.ts
@@ -1,0 +1,72 @@
+import http from 'http';
+
+export interface SendJsonOptions {
+  cacheControl?: string;
+}
+
+export function sendJson(
+  res: http.ServerResponse,
+  status: number,
+  body: unknown,
+  options: SendJsonOptions = {}
+): void {
+  if (res.headersSent) {
+    return;
+  }
+  const payload = JSON.stringify(body);
+  res.statusCode = status;
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.setHeader('Content-Length', Buffer.byteLength(payload));
+  if (options.cacheControl) {
+    res.setHeader('Cache-Control', options.cacheControl);
+  } else if (status >= 400) {
+    res.setHeader('Cache-Control', 'no-store');
+  }
+  res.end(payload);
+}
+
+export async function readRequestBody(
+  req: http.IncomingMessage,
+  maxBytes = 1_048_576
+): Promise<string> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of req) {
+    const buffer = typeof chunk === 'string' ? Buffer.from(chunk) : Buffer.from(chunk);
+    total += buffer.length;
+    if (total > maxBytes) {
+      throw new Error('Request body is too large.');
+    }
+    chunks.push(buffer);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+export async function readJsonBody<T>(
+  req: http.IncomingMessage,
+  maxBytes = 1_048_576
+): Promise<T | undefined> {
+  const raw = await readRequestBody(req, maxBytes);
+  if (!raw) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    throw new Error('Unable to parse JSON body.');
+  }
+}
+
+export function getClientIp(req: http.IncomingMessage): string {
+  const forwarded = req.headers['x-forwarded-for'];
+  if (typeof forwarded === 'string' && forwarded.length > 0) {
+    return forwarded.split(',')[0].trim();
+  }
+  if (Array.isArray(forwarded) && forwarded.length > 0) {
+    return forwarded[0].split(',')[0].trim();
+  }
+  if (req.socket && req.socket.remoteAddress) {
+    return req.socket.remoteAddress;
+  }
+  return 'unknown';
+}

--- a/server/utils/logger.ts
+++ b/server/utils/logger.ts
@@ -1,0 +1,60 @@
+import fs from 'fs';
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+const LOG_FILE = process.env.LOG_FILE ? process.env.LOG_FILE.trim() : '';
+
+function write(line: string) {
+  if (LOG_FILE) {
+    try {
+      fs.appendFileSync(LOG_FILE, `${line}\n`, 'utf8');
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to append log file entry', error);
+    }
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(line);
+}
+
+export function log(level: LogLevel, message: string, metadata: Record<string, unknown> = {}): void {
+  const entry = {
+    level,
+    message,
+    time: new Date().toISOString(),
+    ...metadata
+  };
+
+  write(JSON.stringify(entry));
+}
+
+export function logError(error: unknown, metadata: Record<string, unknown> = {}): void {
+  if (error instanceof Error) {
+    log('error', error.message, {
+      stack: error.stack,
+      ...metadata
+    });
+  } else {
+    log('error', 'Unknown error', {
+      error,
+      ...metadata
+    });
+  }
+}
+
+export function logRequest(
+  method: string,
+  url: string,
+  statusCode: number,
+  durationMs: number,
+  extra: Record<string, unknown> = {}
+): void {
+  log('info', `${method.toUpperCase()} ${url} ${statusCode}`, {
+    durationMs,
+    statusCode,
+    method: method.toUpperCase(),
+    url,
+    ...extra
+  });
+}

--- a/server/utils/metrics.ts
+++ b/server/utils/metrics.ts
@@ -1,0 +1,104 @@
+interface RouteMetric {
+  count: number;
+  totalDurationMs: number;
+  statuses: Map<number, number>;
+}
+
+const requestMetrics = new Map<string, RouteMetric>();
+const licenseDownloads = new Map<string, number>();
+let totalRequests = 0;
+let rateLimitBlocks = 0;
+
+export function recordRequest(
+  method: string,
+  route: string,
+  statusCode: number,
+  durationMs: number
+): void {
+  totalRequests += 1;
+  const key = `${method.toUpperCase()} ${route}`;
+  const metric = requestMetrics.get(key) ?? { count: 0, totalDurationMs: 0, statuses: new Map<number, number>() };
+  metric.count += 1;
+  metric.totalDurationMs += durationMs;
+  metric.statuses.set(statusCode, (metric.statuses.get(statusCode) ?? 0) + 1);
+  requestMetrics.set(key, metric);
+}
+
+export function recordRateLimit(): void {
+  rateLimitBlocks += 1;
+}
+
+export function recordLicenseDownload(licenseId: string): void {
+  const key = licenseId.trim();
+  if (!key) {
+    return;
+  }
+  licenseDownloads.set(key, (licenseDownloads.get(key) ?? 0) + 1);
+}
+
+export interface MetricsSnapshot {
+  totalRequests: number;
+  rateLimitBlocks: number;
+  routes: Array<{
+    key: string;
+    count: number;
+    avgDurationMs: number;
+    statuses: Record<number, number>;
+  }>;
+  licenseDownloads: Record<string, number>;
+}
+
+export function getMetricsSnapshot(): MetricsSnapshot {
+  const routes: MetricsSnapshot['routes'] = [];
+  for (const [key, metric] of requestMetrics) {
+    const statuses: Record<number, number> = {};
+    for (const [status, count] of metric.statuses) {
+      statuses[status] = count;
+    }
+    routes.push({
+      key,
+      count: metric.count,
+      avgDurationMs: metric.count > 0 ? metric.totalDurationMs / metric.count : 0,
+      statuses
+    });
+  }
+
+  const downloadEntries: Record<string, number> = {};
+  for (const [licenseId, count] of licenseDownloads) {
+    downloadEntries[licenseId] = count;
+  }
+
+  return {
+    totalRequests,
+    rateLimitBlocks,
+    routes,
+    licenseDownloads: downloadEntries
+  };
+}
+
+export function renderPrometheusMetrics(): string {
+  const snapshot = getMetricsSnapshot();
+  const lines: string[] = [];
+  lines.push('# HELP iqn_requests_total Total HTTP requests handled by the IQN API');
+  lines.push('# TYPE iqn_requests_total counter');
+  lines.push(`iqn_requests_total ${snapshot.totalRequests}`);
+  lines.push('# HELP iqn_rate_limit_blocks_total Requests blocked by the rate limiter');
+  lines.push('# TYPE iqn_rate_limit_blocks_total counter');
+  lines.push(`iqn_rate_limit_blocks_total ${snapshot.rateLimitBlocks}`);
+  lines.push('# HELP iqn_request_duration_ms Average request duration in milliseconds');
+  lines.push('# TYPE iqn_request_duration_ms gauge');
+  for (const route of snapshot.routes) {
+    const label = route.key.replace(/"/g, '\\"');
+    lines.push(`iqn_request_duration_ms{route="${label}"} ${route.avgDurationMs.toFixed(2)}`);
+    for (const [status, count] of Object.entries(route.statuses)) {
+      lines.push(`iqn_requests_by_status_total{route="${label}",status="${status}"} ${count}`);
+    }
+  }
+  lines.push('# HELP iqn_license_downloads_total License specific exam downloads');
+  lines.push('# TYPE iqn_license_downloads_total counter');
+  for (const [licenseId, count] of Object.entries(snapshot.licenseDownloads)) {
+    const label = licenseId.replace(/"/g, '\\"');
+    lines.push(`iqn_license_downloads_total{license="${label}"} ${count}`);
+  }
+  return `${lines.join('\n')}\n`;
+}

--- a/server/utils/rateLimiter.ts
+++ b/server/utils/rateLimiter.ts
@@ -1,0 +1,42 @@
+interface RateLimitConfig {
+  windowMs: number;
+  limit: number;
+}
+
+interface RateLimitState {
+  expiresAt: number;
+  count: number;
+}
+
+const globalState = new Map<string, RateLimitState>();
+
+export function checkRateLimit(
+  key: string,
+  config: RateLimitConfig
+): boolean {
+  const now = Date.now();
+  const state = globalState.get(key);
+
+  if (!state || state.expiresAt <= now) {
+    globalState.set(key, {
+      expiresAt: now + config.windowMs,
+      count: 1
+    });
+    return true;
+  }
+
+  if (state.count >= config.limit) {
+    return false;
+  }
+
+  state.count += 1;
+  return true;
+}
+
+export function getRateLimitReset(key: string, defaultWindow: number): number {
+  const state = globalState.get(key);
+  if (!state) {
+    return Date.now() + defaultWindow;
+  }
+  return state.expiresAt;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Play, ListChecks, Moon, Sun, Github } from 'lucide-react';
-import { ExamView, ReviewView } from './components';
+import { ExamView, ReviewView, LicenseStatusBanner } from './components';
 import { Button, Badge } from './components/ui';
 import { useExamStore } from './store/useExamStore';
 import { useTimer } from './hooks/useTimer';
 import { calcSummary, shuffleInPlace } from './utils/helpers';
-import { loadAllQAQuestions, pickWithCoverage, buildExamFromQuestions, getExamSetQuestions } from './utils/qaLoader';
+import { loadAllQAQuestions, pickWithCoverage, buildExamFromQuestions, getExamSetQuestions, refreshLicenseStatus } from './utils/qaLoader';
 
 function App() {
   const [isDarkMode, setIsDarkMode] = useState(() => {
@@ -70,6 +70,10 @@ function App() {
   useEffect(() => {
     void startNewExamFromQA();
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    void refreshLicenseStatus();
   }, []);
 
   // Remove fixed default duration; duration will be set to number of questions when building the exam
@@ -269,6 +273,9 @@ function App() {
               </Button>
             </div>
           </motion.div>
+          <div className="mt-4">
+            <LicenseStatusBanner />
+          </div>
         </header>
 
         {questionLoadError && (

--- a/src/components/LicenseStatusBanner.tsx
+++ b/src/components/LicenseStatusBanner.tsx
@@ -1,0 +1,80 @@
+import { ShieldCheck, AlertTriangle, Clock } from 'lucide-react';
+import { useLicenseStore } from '../store/useLicenseStore';
+import { Badge } from './ui';
+
+function formatDate(value?: string): string | null {
+  if (!value) {
+    return null;
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  });
+}
+
+const STATUS_STYLES: Record<string, { label: string; badge: 'success' | 'warning' | 'error' | 'secondary' | 'info' }> = {
+  active: { label: 'Active', badge: 'success' },
+  trial: { label: 'Trial', badge: 'info' },
+  revoked: { label: 'Revoked', badge: 'error' },
+  expired: { label: 'Expired', badge: 'warning' },
+  unknown: { label: 'Unknown', badge: 'warning' }
+};
+
+export function LicenseStatusBanner() {
+  const { info, status, message, lastUpdatedAt } = useLicenseStore((state) => ({
+    info: state.info,
+    status: state.status,
+    message: state.message,
+    lastUpdatedAt: state.lastUpdatedAt
+  }));
+
+  const styles = STATUS_STYLES[status] ?? STATUS_STYLES.unknown;
+  const seatsRemaining = info ? Math.max(0, info.seatsRemaining ?? 0) : null;
+  const seatSummary = info ? `${info.seatsUsed ?? 0}/${info.seatsTotal ?? 0} seats in use` : 'No active license';
+  const expiresDisplay = info ? formatDate(info.expiresAt) : null;
+  const lastSynced = formatDate(lastUpdatedAt ?? undefined);
+
+  return (
+    <div className="w-full rounded-2xl border border-indigo-100 dark:border-indigo-900/40 bg-white/70 dark:bg-gray-900/40 backdrop-blur px-4 py-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+      <div className="flex items-start gap-3">
+        {status === 'active' || status === 'trial' ? (
+          <ShieldCheck className="text-emerald-500" size={22} aria-hidden="true" />
+        ) : (
+          <AlertTriangle className="text-amber-500" size={22} aria-hidden="true" />
+        )}
+        <div>
+          <div className="flex items-center gap-2 flex-wrap">
+            <Badge variant={styles.badge}>{styles.label}</Badge>
+            {info?.tier && (
+              <Badge variant="secondary">Tier: {info.tier}</Badge>
+            )}
+            {info ? (
+              <span className="text-sm text-gray-600 dark:text-gray-400">
+                {seatSummary} • {seatsRemaining ?? 0} seats remaining
+              </span>
+            ) : (
+              <span className="text-sm text-gray-600 dark:text-gray-400">Connect a valid license to download the question bank.</span>
+            )}
+          </div>
+          {expiresDisplay && (
+            <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">Expires {expiresDisplay}</p>
+          )}
+          {message && (
+            <p className="text-sm text-amber-600 dark:text-amber-300 mt-1">{message}</p>
+          )}
+        </div>
+      </div>
+      {lastSynced && (
+        <div className="flex items-center text-xs text-gray-500 dark:text-gray-400 gap-1">
+          <Clock size={14} aria-hidden="true" />
+          <span>Updated {lastSynced}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
 export { Builder } from './Builder/Builder';
 export { ExamView } from './Exam/ExamView';
 export { ReviewView } from './Review/ReviewView';
+export { LicenseStatusBanner } from './LicenseStatusBanner';

--- a/src/store/useLicenseStore.ts
+++ b/src/store/useLicenseStore.ts
@@ -1,0 +1,42 @@
+import { create } from 'zustand';
+import type { LicenseInfo } from '../types';
+
+type LicenseStatus = LicenseInfo['status'] | 'unknown';
+
+interface LicenseStoreState {
+  info: LicenseInfo | null;
+  status: LicenseStatus;
+  message: string | null;
+  lastUpdatedAt: string | null;
+  seatId: string | null;
+  setFromServer: (info: LicenseInfo | null, message?: string | null) => void;
+  setSeatId: (seatId: string) => void;
+  markError: (message: string) => void;
+  clear: () => void;
+}
+
+export const useLicenseStore = create<LicenseStoreState>((set) => ({
+  info: null,
+  status: 'unknown',
+  message: null,
+  lastUpdatedAt: null,
+  seatId: null,
+  setFromServer: (info, message) => {
+    set({
+      info,
+      status: info ? info.status : 'unknown',
+      message: message ?? info?.renewalMessage ?? null,
+      lastUpdatedAt: new Date().toISOString()
+    });
+  },
+  setSeatId: (seatId) => set({ seatId }),
+  markError: (message) => {
+    set({
+      info: null,
+      status: 'unknown',
+      message,
+      lastUpdatedAt: new Date().toISOString()
+    });
+  },
+  clear: () => set({ info: null, status: 'unknown', message: null, lastUpdatedAt: null })
+}));

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -67,3 +67,21 @@ export interface ParseError {
   message: string;
   type: 'warning' | 'error';
 }
+
+export type LicenseStatusValue = 'active' | 'trial' | 'revoked' | 'expired';
+
+export interface LicenseInfo {
+  licenseId: string;
+  status: LicenseStatusValue;
+  seatsTotal: number;
+  seatsUsed: number;
+  seatsRemaining: number;
+  tier?: string;
+  expiresAt?: string;
+  renewalReminderAt?: string;
+  renewalMessage?: string;
+  ownerName?: string;
+  ownerEmail?: string;
+  totalDownloads?: number;
+  lastUsageAt?: string;
+}


### PR DESCRIPTION
## Summary
- persist license, user, seat, and usage data in a JSON database with helpers to issue, renew, revoke, restore, and audit licenses
- extend the Node server with admin and licensing routes, Stripe checkout integration, rate limiting, structured logging, and Prometheus-ready metrics
- surface live license status in the React UI, track seat identifiers per device, and refresh licensing details on load
- document new environment variables, admin workflows, and operations guidance in the README

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf0fb60fb483298d55f83cdc2ca4cc