### PR TITLE
Update dev CORS defaults for Vite port 3000

### DIFF
--- a/config/devServer.d.ts
+++ b/config/devServer.d.ts
@@ -1,0 +1,3 @@
+export declare const DEV_SERVER_HOST: 'localhost';
+export declare const DEV_SERVER_PORT: 3000;
+export declare const DEV_SERVER_ORIGINS: readonly string[];

--- a/config/devServer.js
+++ b/config/devServer.js
@@ -1,0 +1,7 @@
+// Keep these values in sync with the Vite dev server configuration (see vite.config.js).
+export const DEV_SERVER_HOST = 'localhost';
+export const DEV_SERVER_PORT = 3000;
+export const DEV_SERVER_ORIGINS = Object.freeze([
+  `http://${DEV_SERVER_HOST}:${DEV_SERVER_PORT}`,
+  `http://127.0.0.1:${DEV_SERVER_PORT}`,
+]);

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,4 +1,5 @@
 import http from 'http';
+import { DEV_SERVER_ORIGINS } from '../config/devServer.js';
 import { buildExamQuestionsResponse } from './routes/exams.js';
 import { HttpError, verifyLicense } from './middleware/licenseAuth.js';
 
@@ -125,7 +126,8 @@ function handleError(res: http.ServerResponse, error: unknown) {
 
 function buildOriginSet(value: string | undefined): Set<string> {
   if (!value) {
-    return new Set(['http://localhost:5173', 'http://127.0.0.1:5173']);
+    // Defaults mirror the Vite dev server origins defined in config/devServer.js.
+    return new Set(DEV_SERVER_ORIGINS);
   }
 
   const entries = value

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -3,8 +3,9 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "rootDir": "server",
-    "outDir": "dist/server",
+    "rootDir": ".",
+    "outDir": "dist",
+    "allowJs": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
@@ -12,5 +13,5 @@
     "resolveJsonModule": true,
     "verbatimModuleSyntax": true
   },
-  "include": ["server"]
+  "include": ["server", "config/devServer.js"]
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,11 +1,12 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { DEV_SERVER_PORT } from './config/devServer.js'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 3000,
+    port: DEV_SERVER_PORT,
     open: true
   }
 })


### PR DESCRIPTION
## Summary
- add a shared dev server config module so the API and Vite use the same port/origin defaults
- update the API CORS whitelist to default to the Vite dev origins and reference the shared list
- adjust the server TypeScript build output so the shared config ships with compiled code

## Testing
- npm run lint
- npm run server:start (followed by curl checks from http://localhost:3000 and http://127.0.0.1:3000)
- npm run build
- npm run server:build

------
https://chatgpt.com/codex/tasks/task_e_68cf26b01b448329ac7abb3cc1a0eed4