### PR TITLE
Fix QA loader headers initialization

### DIFF
--- a/src/utils/qaLoader.ts
+++ b/src/utils/qaLoader.ts
@@ -47,13 +47,13 @@ export function getQuestionBankVersion(): string {
 }
 
 async function fetchQuestionsFromApi(forceRefresh: boolean): Promise<Question[]> {
-  const headers: HeadersInit = {
+  const headers = new Headers({
     Accept: 'application/json'
-  };
+  });
 
   const token = readLicenseToken();
   if (token) {
-    headers.Authorization = `Bearer ${token}`;
+    headers.set('Authorization', `Bearer ${token}`);
   }
 
   const baseUrl = getApiBaseUrl();


### PR DESCRIPTION
## Summary
- replace the QA loader fetch headers object with a concrete Headers instance
- set the Authorization header using the Headers API when a token exists

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf26b0399c83299fb2250b0d2d9144